### PR TITLE
fix: branch main, COC v2.1, README headings, scope package name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: build
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    timeout-minutes: 6
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        node-version: [24.x, 22.x]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ typings/
 .next
 
 *~
+
+package-lock.json

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,51 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes
+* Focusing on what is best not just for us as individuals, but for the community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without their explicit permission
+* Other conduct which could reasonably be considered inappropriate professionally
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any
+behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement.
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/README.md
+++ b/README.md
@@ -13,19 +13,17 @@
 
 ## Install
 
-```sh
+```
 $ npm install seneca-graph
-```js
-
+```
 <!--START:action-list-->
 
 ## Quick Example
 
-```js
+```
 require('seneca')()
   .use('@seneca/graph')
-```js
-
+```
 ## More Examples
 
 See [test/](test/) for more usage examples.
@@ -444,7 +442,7 @@ Add a directed relation between two nodes in a given graph.
 
 #### Replies With
 
-```json
+```
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -457,8 +455,7 @@ Add a directed relation between two nodes in a given graph.
     id: 'internal graph node identifier'
   }
 }
-```js
-
+```
 ----------
 ### &laquo; `list:rel,role:graph` &raquo;
 
@@ -954,7 +951,7 @@ List nodes connected by a given relation.
 
 #### Replies With
 
-```json
+```
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -972,8 +969,7 @@ List nodes connected by a given relation.
     '...'
   ]
 }
-```js
-
+```
 ----------
 ### &laquo; `role:graph,tree:rel` &raquo;
 
@@ -1551,7 +1547,7 @@ Load tree of nodes connected by given relation.
 
 #### Replies With
 
-```json
+```
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -1572,8 +1568,7 @@ Load tree of nodes connected by given relation.
     '...connected-nodes...'
   ]
 }
-```js
-
+```
 ----------
 
 <!--END:action-desc-->
@@ -1584,10 +1579,9 @@ The [Senecajs org](https://github.com/senecajs/) encourages open participation. 
 
 ### Running tests
 
-```sh
+```
 npm run test
-```js
-
+```
 ## Background
 
 Provides graph data structure operations as Seneca action patterns.

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ Add a directed relation between two nodes in a given graph.
 
 #### Replies With
 
-```json
+```js
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -951,7 +951,7 @@ List nodes connected by a given relation.
 
 #### Replies With
 
-```json
+```js
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -1547,7 +1547,7 @@ Load tree of nodes connected by given relation.
 
 #### Replies With
 
-```json
+```js
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',

--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
-# seneca-graph
+![Seneca](http://senecajs.org/files/assets/seneca-logo.png)
+> A [Seneca.js](http://senecajs.org) plugin
 
+# @seneca/graph
+
+[![npm version](https://img.shields.io/npm/v/@seneca/graph.svg)](https://npmjs.com/package/@seneca/graph)
+[![build](https://github.com/senecajs/seneca-graph/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-graph/actions/workflows/build.yml)
+[![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-graph/badge.svg)](https://snyk.io/test/github/senecajs/seneca-graph)
 [![Npm][BadgeNpm]][Npm]
 [![Travis][BadgeTravis]][Travis]
 [![Coveralls][BadgeCoveralls]][Coveralls]
 
-
-A [Seneca](senecajs.org) plugin that provides basic graph operations.
-
+| ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
+|---|---|
 
 ## Install
 
@@ -18,8 +23,32 @@ $ npm install seneca-graph
 
 <!--START:action-list-->
 
+## Quick Example
 
-## Action Patterns
+```js
+require('seneca')()
+  .use('@seneca/graph')
+```
+
+## More Examples
+
+See [test/](test/) for more usage examples.
+
+## Motivation
+
+Graph data structure plugin for Seneca microservices.
+
+## Support
+
+If you're using this module and need help, you can:
+
+- Post a [github issue](https://github.com/senecajs/seneca-graph/issues)
+- Tweet to [@senecajs](http://twitter.com/senecajs)
+- Ask on the [Gitter](https://gitter.im/senecajs/seneca)
+
+## API
+
+### Action Patterns
 
 * [add:rel,role:graph](#-addrelrolegraph-)
 * [list:rel,role:graph](#-listrelrolegraph-)
@@ -30,8 +59,7 @@ $ npm install seneca-graph
 
 <!--START:action-desc-->
 
-
-## Action Descriptions
+### Action Descriptions
 
 ### &laquo; `add:rel,role:graph` &raquo;
 
@@ -1596,3 +1624,17 @@ Load tree of nodes connected by given relation.
 [Coveralls]: https://coveralls.io/github/senecajs/seneca-graph?branch=master
 [Npm]: https://www.npmjs.com/package/@seneca/graph
 [Travis]: https://travis-ci.org/senecajs/seneca-graph?branch=master
+
+## Contributing
+
+The [Senecajs org](https://github.com/senecajs/) encourages open participation. If you feel you can help in any way, be it with documentation, examples, extra testing, or new features please get in touch.
+
+### Running tests
+
+```sh
+npm run test
+```
+
+## Background
+
+Provides graph data structure operations as Seneca action patterns.

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@
 
 ## Install
 
-```
+```sh
 $ npm install seneca-graph
 ```
 <!--START:action-list-->
 
 ## Quick Example
 
-```
+```js
 require('seneca')()
   .use('@seneca/graph')
 ```
@@ -442,7 +442,7 @@ Add a directed relation between two nodes in a given graph.
 
 #### Replies With
 
-```
+```json
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -951,7 +951,7 @@ List nodes connected by a given relation.
 
 #### Replies With
 
-```
+```json
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -1547,7 +1547,7 @@ Load tree of nodes connected by given relation.
 
 #### Replies With
 
-```
+```json
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -1579,7 +1579,7 @@ The [Senecajs org](https://github.com/senecajs/) encourages open participation. 
 
 ### Running tests
 
-```
+```sh
 npm run test
 ```
 ## Background

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![npm version](https://img.shields.io/npm/v/@seneca/graph.svg)](https://npmjs.com/package/@seneca/graph)
 [![build](https://github.com/senecajs/seneca-graph/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-graph/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-graph/badge.svg)](https://snyk.io/test/github/senecajs/seneca-graph)
+[![Coverage Status](https://coveralls.io/repos/senecajs/seneca-graph/badge.svg?branch=master&service=github)](https://coveralls.io/github/senecajs/seneca-graph?branch=master)
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -14,7 +15,7 @@
 
 ```sh
 $ npm install seneca-graph
-```
+```js
 
 <!--START:action-list-->
 
@@ -23,7 +24,7 @@ $ npm install seneca-graph
 ```js
 require('seneca')()
   .use('@seneca/graph')
-```
+```js
 
 ## More Examples
 
@@ -443,7 +444,7 @@ Add a directed relation between two nodes in a given graph.
 
 #### Replies With
 
-```
+```json
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -456,7 +457,7 @@ Add a directed relation between two nodes in a given graph.
     id: 'internal graph node identifier'
   }
 }
-```
+```js
 
 ----------
 ### &laquo; `list:rel,role:graph` &raquo;
@@ -953,7 +954,7 @@ List nodes connected by a given relation.
 
 #### Replies With
 
-```
+```json
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -971,7 +972,7 @@ List nodes connected by a given relation.
     '...'
   ]
 }
-```
+```js
 
 ----------
 ### &laquo; `role:graph,tree:rel` &raquo;
@@ -1550,7 +1551,7 @@ Load tree of nodes connected by given relation.
 
 #### Replies With
 
-```
+```json
 {
   from: '_from_ parameter, as provided',
   to: '_to_ parameter, as provided',
@@ -1571,7 +1572,7 @@ Load tree of nodes connected by given relation.
     '...connected-nodes...'
   ]
 }
-```
+```js
 
 ----------
 
@@ -1585,7 +1586,7 @@ The [Senecajs org](https://github.com/senecajs/) encourages open participation. 
 
 ```sh
 npm run test
-```
+```js
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,6 @@
 [![npm version](https://img.shields.io/npm/v/@seneca/graph.svg)](https://npmjs.com/package/@seneca/graph)
 [![build](https://github.com/senecajs/seneca-graph/actions/workflows/build.yml/badge.svg)](https://github.com/senecajs/seneca-graph/actions/workflows/build.yml)
 [![Known Vulnerabilities](https://snyk.io/test/github/senecajs/seneca-graph/badge.svg)](https://snyk.io/test/github/senecajs/seneca-graph)
-[![Npm][BadgeNpm]][Npm]
-[![Travis][BadgeTravis]][Travis]
-[![Coveralls][BadgeCoveralls]][Coveralls]
 
 | ![Voxgig](https://www.voxgig.com/res/img/vgt01r.png) | This open source module is sponsored and supported by [Voxgig](https://www.voxgig.com). |
 |---|---|
@@ -18,8 +15,6 @@
 ```sh
 $ npm install seneca-graph
 ```
-
-
 
 <!--START:action-list-->
 
@@ -54,7 +49,6 @@ If you're using this module and need help, you can:
 * [list:rel,role:graph](#-listrelrolegraph-)
 * [role:graph,tree:rel](#-rolegraphtreerel-)
 
-
 <!--END:action-list-->
 
 <!--START:action-desc-->
@@ -65,17 +59,11 @@ If you're using this module and need help, you can:
 
 Add a directed relation between two nodes in a given graph.
 
-
-
-
 #### Examples
-
-
 
 * `add:rel,role:graph,graph:number,rel:lessthan,add:rel,from:<from-id>,to:<to-id>`
   * Idempotently add a pair of nodes to  _number_ graph connected by directed relation _lessthan_ with `from-id` and `to-id` referencing external entity identifiers as per graph definition in options.
 #### Parameters
-
 
 * _graph_ : { type: 'string',
   '$_root':
@@ -453,11 +441,7 @@ Add a directed relation between two nodes in a given graph.
      replacements: null },
   '$_super': {} }
 
-
-
-
 #### Replies With
-
 
 ```
 {
@@ -474,18 +458,12 @@ Add a directed relation between two nodes in a given graph.
 }
 ```
 
-
 ----------
 ### &laquo; `list:rel,role:graph` &raquo;
 
 List nodes connected by a given relation.
 
-
-
-
 #### Examples
-
-
 
 * `list:rel,role:graph,graph:number,rel:lessthan,list:rel`
   * List all nodes in  _number_ graph connected by directed relation _lessthan_
@@ -502,7 +480,6 @@ List nodes connected by a given relation.
 * `list:rel,role:graph,graph:number,rel:lessthan,list:rel,entity:to`
   * List all nodes in  _number_ graph connected by directed relation _lessthan_, loading and including referenced to-side entities
 #### Parameters
-
 
 * _graph_ : { type: 'string',
   '$_root':
@@ -974,11 +951,7 @@ List nodes connected by a given relation.
      replacements: null },
   '$_super': {} }
 
-
-
-
 #### Replies With
-
 
 ```
 {
@@ -1000,18 +973,12 @@ List nodes connected by a given relation.
 }
 ```
 
-
 ----------
 ### &laquo; `role:graph,tree:rel` &raquo;
 
 Load tree of nodes connected by given relation.
 
-
-
-
 #### Examples
-
-
 
 * `role:graph,tree:rel,graph:number,rel:lessthan,from:<from-id>`
   * Load tree of nodes from _number_ graph connected by directed relation _lessthan_ with `from-id` nodes at first level, to default depth of 1.
@@ -1019,7 +986,6 @@ Load tree of nodes connected by given relation.
 * `role:graph,tree:rel,graph:number,rel:lessthan,from:<from-id>,depth:2,entity:to`
   * Load tree of nodes from _number_ graph connected by directed relation _lessthan_ with `from-id` nodes at first level, to depth 2, loading and returning referenced to-side entities.
 #### Parameters
-
 
 * _graph_ : { type: 'string',
   '$_root':
@@ -1582,11 +1548,7 @@ Load tree of nodes connected by given relation.
      replacements: null },
   '$_super': {} }
 
-
-
-
 #### Replies With
-
 
 ```
 {
@@ -1611,19 +1573,9 @@ Load tree of nodes connected by given relation.
 }
 ```
 
-
 ----------
 
-
 <!--END:action-desc-->
-
-
-[BadgeCoveralls]: https://coveralls.io/repos/senecajs/seneca-graph/badge.svg?branch=master&service=github
-[BadgeNpm]: https://badge.fury.io/js/%40seneca%2Fgraph.svg
-[BadgeTravis]: https://travis-ci.org/senecajs/seneca-graph.svg?branch=master
-[Coveralls]: https://coveralls.io/github/senecajs/seneca-graph?branch=master
-[Npm]: https://www.npmjs.com/package/@seneca/graph
-[Travis]: https://travis-ci.org/senecajs/seneca-graph?branch=master
 
 ## Contributing
 


### PR DESCRIPTION
## What changed
- Renamed default branch `master` → `main`
- Added `CODE_OF_CONDUCT.md` v2.1
- Restructured `README.md` with exactly 9 required H1/H2 headings
- Added Voxgig sponsor banner
- Scoped package name
- Added `package-lock.json` to `.gitignore`
- Added `build.yml` GitHub Actions workflow
- Added npm, build and Snyk badges

## Fixes
- `check_default`, `version_codeconduct`, `readme_headings`, `content_readme`, `scoped_package`, `content_gitignore`
